### PR TITLE
Fix: GitHub Integration Name Reference in `goreleaser`

### DIFF
--- a/.deploy/pipelines/goreleaser.yaml
+++ b/.deploy/pipelines/goreleaser.yaml
@@ -21,7 +21,7 @@ steps:
     stage: release
     image: codefresh/cli
     commands:
-      - cf_export GITHUB_TOKEN=$(codefresh get context github-1 --decrypt -o yaml | yq -y .spec.data.auth.password)
+      - cf_export GITHUB_TOKEN=$(codefresh get context github --decrypt -o yaml | yq -y .spec.data.auth.password)
   ReleaseMyApp:
     title: Creating packages
     stage: release


### PR DESCRIPTION
# What

* Fix name of GitHub Integration reference in `goreleaser` pipeline.

# Why

* The `goreleaser` pipeline references the GH integration as `github-1`, whereas in fact it is called `github`. Because of this, it is not possible to get the GITHUB_TOKEN from the context.

# References

#1 
