### PR TITLE
Fix: Add `.gitignore` Entry for File Created by `goreleaser`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ build/
 
 # IDE
 .idea/
+
+# Goreleaser
+codefresh-example-app


### PR DESCRIPTION
# What

* Add gitignore entry for file created by goreleaser.

# Why

<img width="1480" alt="CleanShot 2022-04-25 at 15 26 52@2x" src="https://user-images.githubusercontent.com/10080107/165088726-78444e01-fb23-421b-aab7-dede85a42a09.png">

# References

* https://goreleaser.com/errors/dirty/
