### PR TITLE
Fix: Use Encrypted Variable for `GITHUB_TOKEN` instead of `codefresh get context`

### DIFF
--- a/.deploy/pipelines/goreleaser.yaml
+++ b/.deploy/pipelines/goreleaser.yaml
@@ -16,13 +16,7 @@ steps:
     image: "golang:1.18"
     commands:
       - go build
-  GetGitToken:
-    title: Reading GitHub token
-    stage: release
-    image: codefresh/cli
-    commands:
-      - cf_export GITHUB_TOKEN=$(codefresh get context github --decrypt -o yaml | yq -y .spec.data.auth.password)
-  ReleaseMyApp:
+  ReleaseMyApp: # requires that GITHUB_TOKEN is set as an encrypted variable in CodeFresh (scope: repo)
     title: Creating packages
     stage: release
     image: "goreleaser/goreleaser"


### PR DESCRIPTION
# What

*  Use encrypted variable for github-token instead of `codefresh get context`.

# Why

* Using `codefresh get context` will result in a leaked `GITHUB_TOKEN`.

# References

* https://codefresh.io/docs/docs/codefresh-yaml/variables/#masking-variables-in-logs
