### PR TITLE
Fix: Add Step Dependency in CI Pipeline on Cloning Codebase

### DIFF
--- a/.deploy/pipelines/docker-build.yaml
+++ b/.deploy/pipelines/docker-build.yaml
@@ -17,4 +17,3 @@ steps:
     working_directory: ./
     tag: modules
     dockerfile: Dockerfile
-    disable_push: 'match("${{CF_BRANCH}}", "master", false) == false'


### PR DESCRIPTION
# What

* Add step dependency in CI pipeline for cloning codebase.

# Why

* CI pipeline is a pipeline with parallel steps, but the steps should depend on the `main_clone` step. 

# References

#7 
