### PR TITLE
Fix: fix repository name in docker build step

### DIFF
--- a/.deploy/pipelines/docker-build.yaml
+++ b/.deploy/pipelines/docker-build.yaml
@@ -13,7 +13,7 @@ steps:
     title: Building Docker Image
     type: build
     stage: build
-    image_name: ${{CF_REPO_NAME}}
+    image_name: "${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}"
     working_directory: ./
     tag: modules
     dockerfile: Dockerfile


### PR DESCRIPTION
# What

* Fix repository name in docker build step

# Why

* Repository name should contain the GitHub owner name.

# References

* #7 
